### PR TITLE
Adds mock ability to the ENI and Ifcfg providers

### DIFF
--- a/etc/example_os_net_config_1.json
+++ b/etc/example_os_net_config_1.json
@@ -1,0 +1,14 @@
+{ "network_config": [
+        {
+            "type": "ovs_bridge",
+            "name": "br-ctlplane",
+            "use_dhcp": "true",
+            "members": [
+                {
+                    "type": "interface",
+                    "name": "em1"
+                }
+            ]
+        }
+    ]
+}

--- a/etc/example_os_net_config_2.json
+++ b/etc/example_os_net_config_2.json
@@ -1,0 +1,19 @@
+{ "network_config": [
+        {
+            "type": "ovs_bridge",
+            "name": "br-ctlplane",
+            "use_dhcp": "true",
+            "members": [
+                {
+                    "type": "ovs_bond",
+                    "name": "bond1",
+                    "use_dhcp": "true",
+                    "members": [
+                        { "type": "interface", "name": "em1" },
+                        { "type": "interface", "name": "em2" }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/etc/example_os_net_config_3.json
+++ b/etc/example_os_net_config_3.json
@@ -1,0 +1,21 @@
+{ "network_config": [
+        {
+            "type": "ovs_bridge",
+            "name": "br-ctlplane",
+            "members": [
+                {
+                    "type": "vlan",
+                    "device": "em1",
+                    "vlan_id": "16",
+                    "addresses": [{
+                        "ip_netmask": "192.0.2.1/24"
+                    }],
+                    "routes": [{
+                        "next_hop": "192.0.2.1",
+                        "ip_netmask": "192.0.2.1/24"
+                    }]
+                }
+            ]
+        }
+    ]
+}

--- a/os_net_config/cli.py
+++ b/os_net_config/cli.py
@@ -57,6 +57,13 @@ def parse_opts(argv):
 
     parser.add_argument('--version', action='version',
                         version=os_net_config.__version__)
+    parser.add_argument(
+        '-m', '--mock',
+        dest="mock",
+        action='store_true',
+        help="Return the configuration commands, without applying them.",
+        required=False)
+
     opts = parser.parse_args(argv[1:])
 
     return opts
@@ -89,7 +96,7 @@ def main(argv=sys.argv):
         elif opts.provider == 'eni':
             provider = impl_eni.ENINetConfig()
         elif opts.provider == 'iproute':
-            provider = impl_iproute.IprouteNetConfig()
+            provider = impl_iproute.IPRouteNetConfig()
         else:
             logger.error('Invalid provider specified.')
             return 1
@@ -115,8 +122,12 @@ def main(argv=sys.argv):
     for iface_json in iface_array:
         obj = objects.object_from_json(iface_json)
         provider.addObject(obj)
-    provider.apply()
-    return 0
+    if opts.mock:
+        res = provider.apply(mock=True)
+        print res
+    else:
+        provider.apply()
+        return 0
 
 
 if __name__ == '__main__':

--- a/os_net_config/impl_eni.py
+++ b/os_net_config/impl_eni.py
@@ -159,7 +159,7 @@ class ENINetConfig(os_net_config.NetConfig):
         self.routes[interface_name] = data
         logger.debug('route data: %s' % self.routes[interface_name])
 
-    def apply(self):
+    def apply(self, mock=False):
         new_config = ""
 
         # write out bridges first. This ensures that an ifup -a
@@ -175,6 +175,8 @@ class ENINetConfig(os_net_config.NetConfig):
             new_config += iface_data
 
         if (utils.diff(_network_config_path(), new_config)):
+            if mock:
+                return new_config
             for interface in self.interfaces.keys():
                 logger.info('running ifdown on interface: %s' % interface)
                 processutils.execute('/sbin/ifdown', interface,

--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -162,8 +162,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         if bond.routes:
             self._addRoutes(bond.name, bond.routes)
 
-    def apply(self):
-        logger.info('applying network configs...')
+    def apply(self, mock=False):
+        if not mock:
+            logger.info('applying network configs...')
         restart_interfaces = []
         restart_bridges = []
         update_files = {}
@@ -175,7 +176,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                 restart_interfaces.append(interface_name)
                 update_files[ifcfg_config_path(interface_name)] = iface_data
                 update_files[route_config_path(interface_name)] = route_data
-            else:
+            elif not mock:
                 logger.info('No changes required for interface: %s' %
                             interface_name)
 
@@ -186,8 +187,14 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                 restart_bridges.append(bridge_name)
                 update_files[bridge_config_path(bridge_name)] = bridge_data
                 update_files[route_config_path(bridge_name)] = route_data
-            else:
+            elif not mock:
                 logger.info('No changes required for bridge: %s' % bridge_name)
+
+        if mock:
+            mock_str = ""
+            for location, data in update_files.iteritems():
+                mock_str += "%s:\n%s" % (location, data)
+            return mock_str
 
         for interface in restart_interfaces:
             logger.info('running ifdown on interface: %s' % interface)


### PR DESCRIPTION
Specifying mock=True for 'apply' will return a string
representing the changes required, or commands to be used
in order to implement the requested/specified configuration.

This is also exposed to the cli, with -m (--mock), e.g.

os-net-config --mock -c ./etc/example_os_net_config_1.json -p eni
